### PR TITLE
Enable whitelist

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 
+# Prevent accidentally running this role
+firewalld_enabled: false
+
 # Defines the path to the firewall-cmd command
 firewallcmd_path: /bin/firewall-cmd
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,19 +1,32 @@
 ---
 
-- import_tasks: install_enable.yml
-  tags:
-    - firewalld-install-enable
+- block:
 
-- import_tasks: service_setup.yml
-  when: service_definitions is defined
-  tags:
-    - firewalld-service-definitions
+    - name: Check firewalld enabled status
+      assert: 
+        that: firewalld_enabled | bool
+        success_msg: 'Firewall configuration enabled'
+        fail_msg: 'FIREWALL CONFIGURATION DISABLED'
 
-- import_tasks: ipset_setup.yml
-  when: ipset_definitions is defined
-  tags:
-    - firewalld-ipset-definitions
+    - include_tasks: install_enable.yml
+      tags:
+      - firewalld-install-enable
 
-- import_tasks: zone_setup.yml
-  tags:
-    - firewalld-zone-definitions
+    - include_tasks: service_setup.yml
+      when: service_definitions is defined
+      tags:
+        - firewalld-service-definitions
+
+    - include_tasks: ipset_setup.yml
+      when: ipset_definitions is defined
+      tags:
+        - firewalld-ipset-definitions
+
+    - include_tasks: zone_setup.yml
+      tags:
+        - firewalld-zone-definitions
+
+  rescue:
+    - name: How to enable firewalld
+      debug:
+        msg: "Please set 'firewalld_enabled' to 'true' to enable this role"


### PR DESCRIPTION
This is a very heavy block list. If "firewalld_enabled" isn't explicitly set to a truthy value, everything in this role will be skipped, even installing or enabling firewalld (perhaps another systems is being used? Like nftables?)

JIRA: LX-1497 / Implement Ansible Firewalld Role Deny/Allow List Capability